### PR TITLE
cleanup: adjust kubefin components resource requests

### DIFF
--- a/config_template/core/deployments/kubefin-agent.yaml
+++ b/config_template/core/deployments/kubefin-agent.yaml
@@ -87,11 +87,8 @@ spec:
         image: otel/opentelemetry-collector-contrib:0.72.0
         resources:
           requests:
-            cpu: 10m
-            memory: 10Mi
-          limits:
             cpu: 500m
-            memory: 500Mi
+            memory: 1500Mi
         volumeMounts:
           - mountPath: /etc/otelcol-contrib/config.yaml
             name: otel-collector-config

--- a/config_template/core/deployments/kubefin-cost-analyzer.yaml
+++ b/config_template/core/deployments/kubefin-cost-analyzer.yaml
@@ -46,12 +46,9 @@ spec:
             - name: QUERY_BACKEND_ENDPOINT
               value: "http://mimir.kubefin.svc.cluster.local:9009/prometheus"
           resources:
-            requests:
-              cpu: 10m
-              memory: 10Mi
-            limits:
-              cpu: 500m
-              memory: 500Mi
+          requests:
+            cpu: 500m
+            memory: 1Gi
           ports:
             - name: healthcheck
               containerPort: 9090

--- a/config_template/third_party/mimir.yaml
+++ b/config_template/third_party/mimir.yaml
@@ -27,11 +27,8 @@ spec:
             name: http
         resources:
           requests:
-            cpu: 10m
-            memory: 10Mi
-          limits:
             cpu: 500m
-            memory: 500Mi
+            memory: 1Gi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
             - mountPath: /etc/mimir/config.yaml


### PR DESCRIPTION
Fixes #none



<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

I tested in my local simulation environment,  it has:
* 200 nodes(each one 32Core/256Gi)
* 2000 pods
For running the kubefin, it costs following resource:
![image](https://github.com/kubefin/kubefin/assets/147619816/7a842fe8-2abb-44cd-b737-dff6c507f06a)

So:
* adjust kubefin components resource requests

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
