### PR TITLE
Added support for helm deployment of kubefin

### DIFF
--- a/charts/kubefin-agent/.helmignore
+++ b/charts/kubefin-agent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kubefin-agent/Chart.yaml
+++ b/charts/kubefin-agent/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: kubefin-agent
+description: A Helm chart for kubefin-agent
+sources:
+  - https://github.com/kubefin/kubefin
+keywords:
+  - kubefin
+  - kubefin-agent
+  - FinOps
+type: application
+version: 0.1.0
+appVersion: "0.1.2"

--- a/charts/kubefin-agent/templates/_helpers.tpl
+++ b/charts/kubefin-agent/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubefin-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubefin-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubefin-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubefin-agent.labels" -}}
+helm.sh/chart: {{ include "kubefin-agent.chart" . }}
+{{ include "kubefin-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubefin-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubefin-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/kubefin-agent/templates/kubefin-agent-config-cm.yaml
+++ b/charts/kubefin-agent/templates/kubefin-agent-config-cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kubefin-agent.fullname" . }}
+data:
+  {{- tpl .Values.config $ | nindent 2 }}

--- a/charts/kubefin-agent/templates/kubefin-agent-deployment.yaml
+++ b/charts/kubefin-agent/templates/kubefin-agent-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kubefin-agent.fullname" . }}
+  labels:
+    {{- include "kubefin-agent.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kubefin-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/kube-agent-config: {{ include (print $.Template.BasePath "/kubefin-agent-config-cm.yaml") . | sha256sum }}
+        {{- if .Values.otel.enabled }}
+        checksum/otel-collector-config: {{ include (print $.Template.BasePath "/otel-collector-config.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "kubefin-agent.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "kubefin-agent.fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: LEADER_ELECTION_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          envFrom:
+            - configMapRef:
+                name: {{ include "kubefin-agent.fullname" . }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- if .Values.otel.enabled }}
+        - name: otel-collector
+          image: "{{ .Values.otel.image.repository }}:{{ .Values.otel.image.tag }}"
+          imagePullPolicy: {{ .Values.otel.image.pullPolicy }}
+          {{- with .Values.otel.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: otel-collector-config
+              mountPath: /etc/otelcol-contrib/config.yaml
+              subPath: config.yaml
+              readOnly: true
+      volumes:
+        - name: otel-collector-config
+          configMap:
+            name: {{ include "kubefin-agent.fullname" . }}-otel-collector-config
+      {{- end }}

--- a/charts/kubefin-agent/templates/kubefin-agent-podmonitor.yaml
+++ b/charts/kubefin-agent/templates/kubefin-agent-podmonitor.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "kubefin-agent.fullname" . }}
+  labels:
+    {{- include "kubefin-agent.labels" . | nindent 4 }}
+    {{- with .Values.podMonitor.additionalLabels }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.podMonitor.jobLabel }}
+  jobLabel: {{ .Values.podMonitor.jobLabel }}
+  {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: metrics
+      {{- if .Values.podMonitor.interval }}
+      interval: {{ .Values.podMonitor.interval }}
+      {{- end }}
+      {{- if .Values.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.podMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.podMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  selector:
+    matchLabels:
+      {{- include "kubefin-agent.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/kubefin-agent/templates/otel-collector-config.yaml
+++ b/charts/kubefin-agent/templates/otel-collector-config.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.otel.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kubefin-agent.fullname" . }}-otel-collector-config
+  labels:
+    {{- include "kubefin-agent.labels" . | nindent 4 }}
+    app: otel-collector
+data:
+  config.yaml: |
+    {{- tpl .Values.otel.config $ | nindent 4 }}
+{{- end }}

--- a/charts/kubefin-agent/templates/rbac.yaml
+++ b/charts/kubefin-agent/templates/rbac.yaml
@@ -1,0 +1,57 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubefin-agent.fullname" .}}
+  labels:
+    {{- include "kubefin-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kubefin-agent.fullname" .}}
+  labels:
+    {{- include "kubefin-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update", "patch", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubefin-agent.fullname" .}}
+  labels:
+    {{- include "kubefin-agent.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubefin-agent.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kubefin-agent.fullname" .}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kubefin-agent.fullname" .}}
+  labels:
+    {{- include "kubefin-agent.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubefin-agent.fullname" .}}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "kubefin-agent.fullname" .}}

--- a/charts/kubefin-agent/templates/serviceaccount.yaml
+++ b/charts/kubefin-agent/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kubefin-agent.fullname" . }}
+  labels:
+    {{- include "kubefin-agent.labels" . | nindent 4 }}

--- a/charts/kubefin-agent/values.yaml
+++ b/charts/kubefin-agent/values.yaml
@@ -1,0 +1,118 @@
+replicaCount: 1
+
+image:
+  repository: kubefin/kubefin-agent
+  tag: "v0.1.2"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+extraArgs: []
+# - --v=6
+
+config: |
+  CLOUD_PROVIDER: "default"
+  CLUSTER_NAME: "kubefin-server"
+  CLUSTER_ID: ""
+  CUSTOM_CPU_CORE_HOUR_PRICE: ""
+  CUSTOM_RAM_GB_HOUR_PRICE: ""
+  NODE_CPU_DEVIATION: "0.0"
+  NODE_RAM_DEVIATION: "0.4"
+  CPUCORE_RAMGB_PRICE_RATIO: "3"
+
+resources: {}
+  # requests:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+
+podMonitor:
+  # Create PodMonitor Resource for scraping metrics using PrometheusOperator, set to true to create a Pod Monitor Entry
+  enabled: false
+  # The name of the label on the target service to use as the job name in prometheus.
+  jobLabel: ""
+  # Interval at which metrics should be scraped
+  interval: 15s
+  # The timeout after which the scrape is ended
+  scrapeTimeout: ""
+  # Metrics relabelings to add to the scrape endpoint
+  metricRelabelings: []
+  # RelabelConfigs to apply to samples before scraping
+  relabelings: []
+  # Additional labels
+  additionalLabels: {}
+
+otel:
+  enabled: true
+  image:
+    repository: otel/opentelemetry-collector-contrib
+    tag: "0.72.0"
+    pullPolicy: IfNotPresent
+
+  resources:
+    # requests:
+    #   cpu: 500m
+    #   memory: 1500Mi
+    # limits:
+    #   cpu: 500m
+    #   memory: 1500Mi
+
+  config: |
+    receivers:
+      prometheus_simple:
+        # The allowed min period is 15s
+        collection_interval: 15s
+        # Kubefin-agent metrics endpoint
+        endpoint: "127.0.0.1:8080"
+        metrics_path: "/metrics"
+        use_service_account: false
+    processors:
+      batch:
+      memory_limiter:
+        # 80% of maximum memory up to 2G
+        limit_mib: 1500
+        # 25% of limit up to 2G
+        spike_limit_mib: 512
+        check_interval: 5s
+    extensions:
+      zpages: {}
+      memory_ballast:
+        # Memory Ballast size should be max 1/3 to 1/2 of memory.
+        size_mib: 683
+    exporters:
+      prometheusremotewrite:
+        # namespace: ""
+        # Prometheus data format compatible indicator reporting interface.
+        # Example:
+        # Insert data into thanos. endpoint: "http://thanos-receive.example.local/api/v1/receive"
+        # Insert data into mimir. endpoint: "http://mimir-distributor.example.local/api/v1/push"
+        endpoint: "http://mimir.kubefin.svc.cluster.local:9009/api/v1/push"
+    service:
+      telemetry:
+      extensions: [zpages, memory_ballast]
+      pipelines:
+        metrics:
+          receivers: [prometheus_simple]
+          processors: [memory_limiter, batch]
+          exporters: [prometheusremotewrite]
+
+podAnnotations: {}
+
+# Affinity Configuration, String Type.
+affinity: ""
+# Example:
+# affinity: |
+#   podAntiAffinity:
+#     preferredDuringSchedulingIgnoredDuringExecution:
+#       - podAffinityTerm:
+#           labelSelector:
+#             matchLabels:
+#               {{- include "kubefin-agent.selectorLabels" . | nindent 12 }}
+#           topologyKey: kubernetes.io/hostname
+#         weight: 100
+
+nodeSelector: {}
+
+tolerations: []

--- a/charts/kubefin-cost-analyzer/.helmignore
+++ b/charts/kubefin-cost-analyzer/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kubefin-cost-analyzer/Chart.yaml
+++ b/charts/kubefin-cost-analyzer/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: kubefin-cost-analyzer
+description: A Helm chart for kubefin-cost-analyzer
+sources:
+  - https://github.com/kubefin/kubefin
+keywords:
+  - kubefin
+  - kubefin-cost-analyzer
+  - kubefin-dashboard
+  - FinOps
+type: application
+version: 0.1.0
+appVersion: "0.1.2"

--- a/charts/kubefin-cost-analyzer/templates/NOTES.txt
+++ b/charts/kubefin-cost-analyzer/templates/NOTES.txt
@@ -1,0 +1,17 @@
+1. Get the application URL by running these commands
+{{ if and .Values.standalone .Values.ingress.enabled }}
+{{- if .Values.ingress.tls }}
+    echo "Visit https://{{ .Values.ingress.host }} to use kubefin-dashbard"
+    https://{{ .Values.ingress.host }}
+{{- else }}
+    echo "Visit http://{{ .Values.ingress.host }} to use kubefin-dashbard"
+    http://{{ .Values.ingress.host }}
+{{- end }}
+{{ else }}
+    echo "Visit http://127.0.0.1:{{ .Values.dashboard.service.port }} to use kubefin-dashbard"
+    {{- if and .Values.standalone }}
+    kubectl port-forward -n {{ .Release.Namespace }} service/{{ include "kubefin-dashboard.fullname" . }} {{ .Values.dashboard.service.port }}
+    {{- else }}
+    kubectl port-forward -n {{ .Release.Namespace }} service/{{ include "kubefin-cost-analyzer.fullname" . }} {{ .Values.dashboard.service.port }}
+    {{- end }}
+{{ end }}

--- a/charts/kubefin-cost-analyzer/templates/_helpers.tpl
+++ b/charts/kubefin-cost-analyzer/templates/_helpers.tpl
@@ -1,0 +1,84 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubefin-cost-analyzer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "kubefin-dashboard.name" -}}
+{{- printf "%s" "kubefin-dashboard"  }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubefin-cost-analyzer.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "kubefin-dashboard.fullname" -}}
+{{- if eq .Release.Name .Chart.Name }}
+{{- include "kubefin-dashboard.name" . }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name (include "kubefin-dashboard.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubefin-cost-analyzer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Kubefin-cost-analyzer labels
+*/}}
+{{- define "kubefin-cost-analyzer.labels" -}}
+helm.sh/chart: {{ include "kubefin-cost-analyzer.chart" . }}
+{{ include "kubefin-cost-analyzer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Kubefin-dashboard labels
+*/}}
+{{- define "kubefin-dashboard.labels" -}}
+helm.sh/chart: {{ include "kubefin-cost-analyzer.chart" . }}
+{{ include "kubefin-dashboard.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Kubefin-cost-analyzer selector labels
+*/}}
+{{- define "kubefin-cost-analyzer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubefin-cost-analyzer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Kubefin-dashboard selector labels
+*/}}
+{{- define "kubefin-dashboard.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubefin-dashboard.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/kubefin-cost-analyzer/templates/ingress.yaml
+++ b/charts/kubefin-cost-analyzer/templates/ingress.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ include "kubefin-dashboard.fullname" . }}
+  labels:
+    {{- include "kubefin-dashboard.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                {{- if .Values.standalone }}
+                name: {{ include "kubefin-dashboard.fullname" . }}
+                {{- else }}
+                name: {{ include "kubefin-cost-analyzer.fullname" . }}
+                {{- end }}
+                port:
+                  name: dashboard
+              {{- else }}
+              {{- if .Values.standalone }}
+              serviceName: {{ include "kubefin-dashboard.fullname" . }}
+              {{- else }}
+              serviceName: {{ include "kubefin-cost-analyzer.fullname" . }}
+              {{- end }}
+              servicePort: {{ .Values.dashboard.service.port }}
+              {{- end }}
+          - path: /api/v1
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "kubefin-cost-analyzer.fullname" . }}
+                port:
+                  name: server
+              {{- else }}
+              serviceName: {{ include "kubefin-cost-analyzer.fullname" . }}
+              servicePort: {{ .Values.costAnalyzer.service.port }}
+              {{- end }}
+{{- end }}

--- a/charts/kubefin-cost-analyzer/templates/kubefin-cost-analyzer-deploment.yaml
+++ b/charts/kubefin-cost-analyzer/templates/kubefin-cost-analyzer-deploment.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kubefin-cost-analyzer.fullname" . }}
+  labels:
+    {{- include "kubefin-cost-analyzer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.costAnalyzer.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kubefin-cost-analyzer.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.costAnalyzer.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "kubefin-cost-analyzer.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "kubefin-cost-analyzer.name" . }}
+          image: "{{ .Values.costAnalyzer.image.repository }}:{{ .Values.costAnalyzer.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.costAnalyzer.image.pullPolicy }}
+          {{- with .Values.costAnalyzer.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: QUERY_BACKEND_ENDPOINT
+              value: {{ tpl .Values.costAnalyzer.query_backend_endpoint $ | quote }}
+          ports:
+            - name: server
+              containerPort: 8080
+          {{- with .Values.costAnalyzer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- if not .Values.standalone }}
+        - name: {{ include "kubefin-dashboard.name" . }}
+          image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
+          ports:
+            - name: dashboard
+              containerPort: 80
+          {{- with .Values.dashboard.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dashboard.Probe.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: dashboard
+            initialDelaySeconds: {{ .Values.dashboard.Probe.startupProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.dashboard.Probe.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.dashboard.Probe.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dashboard.Probe.startupProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.dashboard.Probe.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: dashboard
+            initialDelaySeconds: {{ .Values.dashboard.Probe.readinessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.dashboard.Probe.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.dashboard.Probe.readinessProbe.successThreshold }}
+            periodSeconds: {{ .Values.dashboard.Probe.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dashboard.Probe.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.dashboard.Probe.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: dashboard
+            initialDelaySeconds: {{ .Values.dashboard.Probe.livenessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.dashboard.Probe.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.dashboard.Probe.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dashboard.Probe.livenessProbe.timeoutSeconds }}
+          {{- end }}
+      {{- end }}
+      {{- with .Values.costAnalyzer.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.costAnalyzer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.costAnalyzer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kubefin-cost-analyzer/templates/kubefin-dashboard-deploment.yaml
+++ b/charts/kubefin-cost-analyzer/templates/kubefin-dashboard-deploment.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.standalone }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kubefin-dashboard.fullname" . }}
+  labels:
+    {{- include "kubefin-dashboard.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.dashboard.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kubefin-dashboard.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.dashboard.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "kubefin-dashboard.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "kubefin-dashboard.name" . }}
+          image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
+          ports:
+            - name: dashboard
+              containerPort: 80
+          {{- with .Values.dashboard.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dashboard.Probe.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: dashboard
+            initialDelaySeconds: {{ .Values.dashboard.Probe.startupProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.dashboard.Probe.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.dashboard.Probe.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dashboard.Probe.startupProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.dashboard.Probe.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: dashboard
+            initialDelaySeconds: {{ .Values.dashboard.Probe.readinessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.dashboard.Probe.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.dashboard.Probe.readinessProbe.successThreshold }}
+            periodSeconds: {{ .Values.dashboard.Probe.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dashboard.Probe.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.dashboard.Probe.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: dashboard
+            initialDelaySeconds: {{ .Values.dashboard.Probe.livenessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.dashboard.Probe.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.dashboard.Probe.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dashboard.Probe.livenessProbe.timeoutSeconds }}
+          {{- end }}
+      {{- with .Values.dashboard.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/kubefin-cost-analyzer/templates/service.yaml
+++ b/charts/kubefin-cost-analyzer/templates/service.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubefin-cost-analyzer.fullname" . }}
+  labels:
+    {{- include "kubefin-cost-analyzer.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: server
+      port: {{ .Values.costAnalyzer.service.port }}
+      targetPort: server
+  {{- if not .Values.standalone }}
+    - name: dashboard
+      port: {{ .Values.dashboard.service.port }}
+      targetPort: dashboard
+  {{- end }}
+  selector:
+    {{- include "kubefin-cost-analyzer.selectorLabels" . | nindent 4 }}
+---
+{{- if .Values.standalone }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubefin-dashboard.fullname" . }}
+  labels:
+    {{- include "kubefin-dashboard.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: dashboard
+      port: {{ .Values.dashboard.service.port }}
+      targetPort: dashboard
+  selector:
+    {{- include "kubefin-dashboard.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/kubefin-cost-analyzer/values.yaml
+++ b/charts/kubefin-cost-analyzer/values.yaml
@@ -1,0 +1,125 @@
+# If true, deploy cost-analyzer and dashboard separately, otherwise deploy cost-analyzer and dashboard in the same pod.
+#
+# Note: Since the dashboard image adds the kubefin-cost-analyzer api route, the dashboard calls the api through a reverse
+# proxy, and if you use a separate deployment to access the dashboard through the kubectl port-forward method, the call
+# to the api will fail, and you will need to use the ingress exposed service!
+# For more information: https://github.com/kubefin/kubefin/tree/main/dashboard/nginx-config/default.conf
+standalone: false
+
+imagePullSecrets: []
+
+costAnalyzer:
+  replicaCount: 1
+  image:
+    repository: kubefin/kubefin-cost-analyzer
+    pullPolicy: IfNotPresent
+    tag: "v0.1.2"
+
+  # Backend TSDB storage query endpoints
+  # Example:
+  # Querying data from prometheus. query_backend_endpoint: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+  # Querying data from thanos. query_backend_endpoint: "http://thanos-query-frontend.example.local:10902"
+  # Querying data from mimir. query_backend_endpoint: "http://mimir-query-frontend.example.local:9009/prometheus"
+  # Querying data from victoriametrics. query_backend_endpoint: "http://vmselect.example.local:8481/select/<accountID>/prometheus"
+  query_backend_endpoint: ""
+
+  extraArgs: []
+    # - --v=6
+
+  resources: {}
+  #  requests:
+  #    cpu: 500m
+  #    memory: 1Gi
+  #  limits:
+  #    cpu: 500m
+  #    memory: 1Gi
+
+  service:
+    port: 8080
+
+  podAnnotations: {}
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  # Affinity Configuration, String Type.
+  # affinity: ""
+  # Example:
+  # affinity: |
+  #   podAntiAffinity:
+  #     preferredDuringSchedulingIgnoredDuringExecution:
+  #       - podAffinityTerm:
+  #           topologyKey: kubernetes.io/hostname
+  #           labelSelector:
+  #             matchLabels:
+  #               {{- include "kubefin-cost-analyzer.selectorLabels" . | nindent 12 }}
+  #         weight: 100
+
+dashboard:
+  replicaCount: 1
+  image:
+    repository: kubefin/kubefin-dashboard
+    pullPolicy: IfNotPresent
+    tag: "v0.1.2"
+
+  resources: {}
+  #  requests:
+  #    cpu: 100m
+  #    memory: 256Mi
+  #  limits:
+  #    cpu: 100m
+  #    memory: 256Mi
+
+  service:
+    port: 3000
+
+  Probe:
+    startupProbe:
+      enabled: false
+      initialDelaySeconds: 3
+      failureThreshold: 10
+      periodSeconds: 10
+      timeoutSeconds: 1
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 3
+      failureThreshold: 2
+      successThreshold: 2
+      periodSeconds: 10
+      timeoutSeconds: 3
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 3
+      failureThreshold: 2
+      periodSeconds: 10
+      timeoutSeconds: 3
+
+  podAnnotations: {}
+
+  # Affinity Configuration, String Type.
+  # affinity: ""
+  # Example:
+  # affinity: |
+  #   podAntiAffinity:
+  #     preferredDuringSchedulingIgnoredDuringExecution:
+  #       - podAffinityTerm:
+  #           topologyKey: kubernetes.io/hostname
+  #           labelSelector:
+  #             matchLabels:
+  #               {{- include "kubefin-dashboard.selectorLabels" . | nindent 12 }}
+  #         weight: 100
+
+  nodeSelector: {}
+
+  tolerations: []
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  host: kubefin-dashboard.example.local
+  tls: {}
+    # secretName: kubefin-dashboard.example.local

--- a/charts/kubefin/.helmignore
+++ b/charts/kubefin/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kubefin/Chart.lock
+++ b/charts/kubefin/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: kubefin-agent
+  repository: file://../kubefin-agent
+  version: 0.1.0
+- name: kubefin-cost-analyzer
+  repository: file://../kubefin-cost-analyzer
+  version: 0.1.0
+digest: sha256:b3b8d3464fce7788c49618571360dff909b8bd8cf8a6a1c8f2f7e402ef174ea1
+generated: "2023-10-26T14:30:34.018528486+08:00"

--- a/charts/kubefin/Chart.yaml
+++ b/charts/kubefin/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: kubefin
+description: A Helm chart for Kubefin
+sources:
+  - https://github.com/kubefin/kubefin
+keywords:
+  - kubefin
+  - FinOps
+type: application
+version: 0.1.0
+appVersion: "0.1.2"
+dependencies:
+  - name: kubefin-agent
+    repository: "file://../kubefin-agent"
+    version: 0.1.0
+    condition: kubefin-agent.enabled
+  - name: kubefin-cost-analyzer
+    repository: "file://../kubefin-cost-analyzer"
+    version: 0.1.0
+    condition: kubefin-cost-analyzer.enabled

--- a/charts/kubefin/templates/_helpers.tpl
+++ b/charts/kubefin/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubefin.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubefin.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubefin.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Mimir labels
+*/}}
+{{- define "kubefin-mimir.labels" -}}
+helm.sh/chart: {{ include "kubefin.chart" . }}
+{{ include "kubefin-mimir.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.mimir.image.tag | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Mimir selector labels
+*/}}
+{{- define "kubefin-mimir.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubefin.name" . }}-mimir
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/kubefin/templates/mimir-config.yaml
+++ b/charts/kubefin/templates/mimir-config.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.mimir.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kubefin.fullname" . }}-mimir-config
+data:
+  config.yaml: |
+    {{- tpl .Values.mimir.config $ | nindent 4 }}
+{{- end }}

--- a/charts/kubefin/templates/mimir-service.yaml
+++ b/charts/kubefin/templates/mimir-service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.mimir.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubefin.fullname" . }}-mimir
+  labels:
+    {{- include "kubefin-mimir.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.mimir.service.port }}
+      targetPort: http
+  selector:
+    {{- include "kubefin-mimir.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/kubefin/templates/mimir-statefulset.yaml
+++ b/charts/kubefin/templates/mimir-statefulset.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.mimir.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "kubefin.fullname" . }}-mimir
+  labels:
+    {{- include "kubefin-mimir.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "kubefin-mimir.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "kubefin.fullname" . }}-mimir
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/mimir-config.yaml") . | sha256sum }}
+      labels:
+        {{- include "kubefin-mimir.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: mimir
+          args:
+            - -target=all
+            - --config.file=/etc/mimir/config.yaml
+          image: "{{ .Values.mimir.image.repository }}:{{ .Values.mimir.image.tag }}"
+          imagePullPolicy: {{ .Values.mimir.image.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.mimir.service.port }}
+          {{- with .Values.mimir.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.mimir.Probe.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: {{ .Values.mimir.Probe.startupProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.mimir.Probe.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.mimir.Probe.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.mimir.Probe.startupProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.mimir.Probe.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: {{ .Values.mimir.Probe.readinessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.mimir.Probe.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.mimir.Probe.readinessProbe.successThreshold }}
+            periodSeconds: {{ .Values.mimir.Probe.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.mimir.Probe.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.mimir.Probe.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: {{ .Values.mimir.Probe.livenessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.mimir.Probe.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.mimir.Probe.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.mimir.Probe.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          volumeMounts:
+            - name: mimir-config
+              mountPath: /etc/mimir/config.yaml
+              subPath: config.yaml
+              readOnly: true
+      volumes:
+        - name: mimir-config
+          configMap:
+            name: {{ include "kubefin.fullname" . }}-mimir-config
+{{- end }}

--- a/charts/kubefin/values.yaml
+++ b/charts/kubefin/values.yaml
@@ -1,0 +1,263 @@
+global:
+  imagePullSecrets: []
+
+kubefin-agent:
+  enabled: true
+
+  replicaCount: 2
+
+  extraArgs: []
+
+  config: |
+    CLOUD_PROVIDER: "default"
+    CLUSTER_NAME: "kubefin-server"
+    CLUSTER_ID: ""
+    CUSTOM_CPU_CORE_HOUR_PRICE: ""
+    CUSTOM_RAM_GB_HOUR_PRICE: ""
+    NODE_CPU_DEVIATION: "0.0"
+    NODE_RAM_DEVIATION: "0.4"
+    CPUCORE_RAMGB_PRICE_RATIO: "3"
+
+  resources: {}
+  # requests:
+  #   cpu: 500m
+  #   memory: 1500Mi
+  # limits:
+  #   cpu: 500m
+  #   memory: 1500Mi
+
+  podMonitor:
+    # Create PodMonitor Resource for scraping metrics using PrometheusOperator, set to true to create a Pod Monitor Entry
+    enabled: false
+    # The name of the label on the target service to use as the job name in prometheus.
+    jobLabel: ""
+    # Interval at which metrics should be scraped
+    interval: 15s
+    # The timeout after which the scrape is ended
+    scrapeTimeout: ""
+    # Metrics relabelings to add to the scrape endpoint
+    metricRelabelings: []
+    # RelabelConfigs to apply to samples before scraping
+    relabelings: []
+    # Additional labels
+    additionalLabels: {}
+
+  otel:
+    enabled: true
+
+    resources: {}
+    # requests:
+    #   cpu: 500m
+    #   memory: 1500Mi
+    # limits:
+    #   cpu: 500m
+    #   memory: 1500Mi
+
+    config: |
+      receivers:
+        prometheus_simple:
+          # The allowed min period is 15s
+          collection_interval: 15s
+          # Kubefin-agent metrics endpoint
+          endpoint: "127.0.0.1:8080"
+          metrics_path: "/metrics"
+          use_service_account: false
+      processors:
+        batch:
+        memory_limiter:
+          # 80% of maximum memory up to 2G
+          limit_mib: 1500
+          # 25% of limit up to 2G
+          spike_limit_mib: 512
+          check_interval: 5s
+      extensions:
+        zpages: {}
+        memory_ballast:
+          # Memory Ballast size should be max 1/3 to 1/2 of memory.
+          size_mib: 683
+      exporters:
+        prometheusremotewrite:
+          # namespace: ""
+          # Prometheus data format compatible indicator reporting interface.
+          # Example:
+          # Insert data into thanos. endpoint: "http://thanos-receive.example.local/api/v1/receive"
+          # Insert data into mimir. endpoint: "http://mimir-distributor.example.local/api/v1/push"
+          endpoint: 'http://{{ .Release.Name }}-mimir.{{ .Release.Namespace }}:9009/api/v1/push'
+      service:
+        telemetry:
+        extensions: [zpages, memory_ballast]
+        pipelines:
+          metrics:
+            receivers: [prometheus_simple]
+            processors: [memory_limiter, batch]
+            exporters: [prometheusremotewrite]
+
+  podAnnotations: {}
+
+  # Affinity Configuration, String Type.
+  affinity: ""
+  # Example:
+  # affinity: |
+  #   podAntiAffinity:
+  #     preferredDuringSchedulingIgnoredDuringExecution:
+  #       - podAffinityTerm:
+  #           labelSelector:
+  #             matchLabels:
+  #               {{- include "kubefin-agent.selectorLabels" . | nindent 12 }}
+  #           topologyKey: kubernetes.io/hostname
+  #         weight: 100
+
+  nodeSelector: {}
+
+  tolerations: []
+
+kubefin-cost-analyzer:
+  enabled: true
+
+  costAnalyzer:
+    replicaCount: 1
+    image:
+      repository: kubefin/kubefin-cost-analyzer
+      pullPolicy: IfNotPresent
+      tag: "v0.1.2"
+
+    # Backend TSDB storage query endpoints
+    # Example:
+    # Querying data from prometheus. query_backend_endpoint: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+    # Querying data from thanos. query_backend_endpoint: "http://thanos-query-frontend.example.local:10902"
+    # Querying data from mimir. query_backend_endpoint: "http://mimir-query-frontend.example.local:9009/prometheus"
+    # Querying data from victoriametrics. query_backend_endpoint: "http://vmselect.example.local:8481/select/<accountID>/prometheus"
+    query_backend_endpoint: "http://{{ .Release.Name }}-mimir.{{ .Release.Namespace}}:9009/prometheus"
+
+    extraArgs: []
+      # - --v=6
+
+    resources: {}
+    #  requests:
+    #    cpu: 500m
+    #    memory: 1Gi
+    #  limits:
+    #    cpu: 500m
+    #    memory: 1Gi
+
+    podAnnotations: {}
+
+    nodeSelector: {}
+
+    tolerations: []
+
+    # Affinity Configuration, String Type.
+    # affinity: ""
+    # Example:
+    # affinity: |
+    #   podAntiAffinity:
+    #     preferredDuringSchedulingIgnoredDuringExecution:
+    #       - podAffinityTerm:
+    #           topologyKey: kubernetes.io/hostname
+    #           labelSelector:
+    #             matchLabels:
+    #               {{- include "kubefin-cost-analyzer.selectorLabels" . | nindent 12 }}
+    #         weight: 100
+
+
+# You can turn off mimir if you use external storage compatible with the Prometheus data format.
+mimir:
+  enabled: true
+  image:
+    repository: grafana/mimir
+    tag: "2.10.3"
+    imagePullPolicy: "IfNotPresent"
+
+  resources: {}
+  # requests:
+  #   cpu: 500m
+  #   memory: 1Gi
+  # limits:
+  #   cpu: 500m
+  #   memory: 1Gi
+
+  service:
+    port: 9009
+
+  Probe:
+    startupProbe:
+      enabled: true
+      httpGet:
+        path: /ready
+        port: http
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      failureThreshold: 100
+      timeoutSeconds: 5
+    readinessProbe:
+      enabled: true
+      httpGet:
+        path: /ready
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 15
+      failureThreshold: 2
+      successThreshold: 1
+      timeoutSeconds: 5
+
+    livenessProbe:
+      enabled: true
+      httpGet:
+        path: /ready
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 15
+      failureThreshold: 2
+      successThreshold: 1
+      timeoutSeconds: 5
+
+  config: |
+    multitenancy_enabled: false
+
+    blocks_storage:
+      backend: filesystem
+      # This should be changed to pvc(at least)
+      bucket_store:
+        sync_dir: /tmp/mimir/tsdb-sync
+      filesystem:
+        dir: /tmp/mimir/data/tsdb
+      tsdb:
+        dir: /tmp/mimir/tsdb
+
+    compactor:
+      data_dir: /tmp/mimir/compactor
+      sharding_ring:
+        kvstore:
+          store: memberlist
+
+    distributor:
+      ring:
+        instance_addr: 127.0.0.1
+        kvstore:
+          store: memberlist
+
+    ingester:
+      ring:
+        instance_addr: 127.0.0.1
+        kvstore:
+          store: memberlist
+        replication_factor: 1
+
+    ruler_storage:
+      backend: filesystem
+      filesystem:
+        dir: /tmp/mimir/rules
+
+    server:
+      http_listen_port: {{ .Values.mimir.service.port }}
+      log_level: info
+
+    store_gateway:
+      sharding_ring:
+        replication_factor: 1
+
+    # referring to
+    # 1.https://github.com/grafana/loki/issues/5123
+    # 2.https://grafana.com/docs/mimir/latest/references/configuration-parameters/
+    frontend:
+      max_outstanding_per_tenant: 4096


### PR DESCRIPTION
1. added support for helm deployment of kubefin.
2. added support for prometheus scraping kubefin-agent metrics, which can replace Opentelemetry Collector.