### PR TITLE
bug: fix metrics redundancy when the pod not exists

### DIFF
--- a/cmd/kubefin-agent/app/agent.go
+++ b/cmd/kubefin-agent/app/agent.go
@@ -98,6 +98,9 @@ func Run(ctx context.Context, opts *options.AgentOptions) error {
 	if err != nil {
 		return fmt.Errorf("create cloud provider error:%v", err)
 	}
+	if err := provider.ParseClusterInfo(opts); err != nil {
+		return err
+	}
 
 	factory := informers.NewSharedInformerFactory(clientSet, 0)
 	coreResourceInformerLister := getAllCoreResourceLister(factory)
@@ -112,10 +115,6 @@ func Run(ctx context.Context, opts *options.AgentOptions) error {
 		coreResourceInformerLister.NodeInformer.HasSynced,
 		coreResourceInformerLister.PodInformer.HasSynced); !ok {
 		return fmt.Errorf("wait core resource cache sync failed")
-	}
-
-	if err := provider.ParseClusterInfo(opts); err != nil {
-		return err
 	}
 
 	klog.Infof("Start metrics http server")

--- a/config_template/core/deployments/kubefin-agent.yaml
+++ b/config_template/core/deployments/kubefin-agent.yaml
@@ -42,7 +42,7 @@ spec:
         # and substituted here.
         image: {KUBEFIN_AGENT_IAMGE}
         args:
-          - --v=6 # highest log level
+          - --v=4 # debug level log
         resources:
           requests:
             cpu: 500m

--- a/dashboard/web/src/pages/dashboard/components/cluster-cost/cluster-cost-header.jsx
+++ b/dashboard/web/src/pages/dashboard/components/cluster-cost/cluster-cost-header.jsx
@@ -103,7 +103,7 @@ export function ClusterCostHeader(props) {
     let endDateInt = Math.floor(endDate);
     let stepSeconds = 3600;
     // if the start time is less 24 hours before the end time, the step time shoud be days
-    if (endDateInt - startDateInt >= 86400) {
+    if (endDateInt - startDateInt > 86400) {
       stepSeconds = 86400;
     }
     fetchClusterData(startDateInt, endDateInt, stepSeconds);

--- a/pkg/metrics/core/pod_metrics.go
+++ b/pkg/metrics/core/pod_metrics.go
@@ -19,7 +19,6 @@ package core
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
@@ -35,23 +34,8 @@ import (
 	"github.com/kubefin/kubefin/pkg/values"
 )
 
-type PodLevelMetricsCollector struct {
-	metricsClient *versioned.Clientset
-	provider      cloudprice.CloudProviderInterface
-
-	podLister  v1.PodLister
-	nodeLister v1.NodeLister
-
-	// podResourceCostGV will be the node price * pod request resource
-	podResourceCostGV *prometheus.GaugeVec
-
-	podResourceRequestGV *prometheus.GaugeVec
-	podResourceUsageGV   *prometheus.GaugeVec
-}
-
-func NewPodLevelMetricsCollector(client *versioned.Clientset, provider cloudprice.CloudProviderInterface,
-	podLister v1.PodLister, nodeLister v1.NodeLister) *PodLevelMetricsCollector {
-	containerNoneCareLabelKey := []string{
+var (
+	containerNoneCareLabelKey = []string{
 		values.NamespaceLabelKey,
 		values.PodNameLabelKey,
 		values.ClusterNameLabelKey,
@@ -60,11 +44,7 @@ func NewPodLevelMetricsCollector(client *versioned.Clientset, provider cloudpric
 		values.PodScheduledKey,
 		values.LabelsLabelKey,
 	}
-	podResourceCostGV := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: values.PodResoueceCostMetricsName,
-		Help: "The pod level resource cost"}, containerNoneCareLabelKey)
-
-	containerCareLabelKey := []string{
+	containerCareLabelKey = []string{
 		values.NamespaceLabelKey,
 		values.PodNameLabelKey,
 		values.ClusterNameLabelKey,
@@ -74,45 +54,37 @@ func NewPodLevelMetricsCollector(client *versioned.Clientset, provider cloudpric
 		// For multiple container pod, this metrics is needed for cpu/memory size recommendation
 		values.ContainerNameLabelKey,
 	}
-	podResourceRequestGV := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: values.PodResourceRequestMetricsName,
-		Help: "The pod container level resource requested"}, containerCareLabelKey)
-	podResourceUsageGV := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: values.PodResourceUsageMetricsName,
-		Help: "The pod container level resource usage"}, containerCareLabelKey)
 
-	prometheus.MustRegister(podResourceRequestGV, podResourceUsageGV, podResourceCostGV)
-	return &PodLevelMetricsCollector{
-		metricsClient:        client,
-		podLister:            podLister,
-		nodeLister:           nodeLister,
-		provider:             provider,
-		podResourceRequestGV: podResourceRequestGV,
-		podResourceUsageGV:   podResourceUsageGV,
-		podResourceCostGV:    podResourceCostGV,
-	}
+	podResourceCostDesc = prometheus.NewDesc(
+		values.PodResoueceCostMetricsName,
+		"The pod level resource cost",
+		containerNoneCareLabelKey, nil)
+	podResourceRequestDesc = prometheus.NewDesc(
+		values.PodResourceRequestMetricsName,
+		"The pod container level resource requested",
+		containerCareLabelKey, nil)
+	podResourceUsageDesc = prometheus.NewDesc(
+		values.PodResourceUsageMetricsName,
+		"The pod container level resource usage",
+		containerCareLabelKey, nil)
+)
+
+type podResourceCostCollector struct {
+	clusterId   string
+	clusterName string
+
+	metricsClient *versioned.Clientset
+	provider      cloudprice.CloudProviderInterface
+
+	podLister  v1.PodLister
+	nodeLister v1.NodeLister
 }
 
-func (p *PodLevelMetricsCollector) StartCollectPodLevelMetrics(ctx context.Context,
-	interval time.Duration, agentOptions *options.AgentOptions) {
-	ticker := time.NewTicker(interval)
-
-	klog.Infof("Start collecting Pod level metrics")
-	stopCh := ctx.Done()
-	for {
-		select {
-		case <-stopCh:
-			klog.Infof("Stop collecting Pod level metrics")
-			return
-		case <-ticker.C:
-			p.collectPodResourceCost(agentOptions)
-			p.collectPodResourceRequest(agentOptions)
-			p.collectPodResourceUsage(ctx, agentOptions)
-		}
-	}
+func (p *podResourceCostCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- podResourceCostDesc
 }
 
-func (p *PodLevelMetricsCollector) collectPodResourceCost(agentOptions *options.AgentOptions) {
+func (p *podResourceCostCollector) Collect(ch chan<- prometheus.Metric) {
 	pods, err := p.podLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("List all pods error:%v", err)
@@ -133,17 +105,33 @@ func (p *PodLevelMetricsCollector) collectPodResourceCost(agentOptions *options.
 		labels := prometheus.Labels{
 			values.NamespaceLabelKey:    pod.Namespace,
 			values.PodNameLabelKey:      pod.Name,
-			values.ClusterNameLabelKey:  agentOptions.ClusterName,
-			values.ClusterIdLabelKey:    agentOptions.ClusterId,
+			values.ClusterNameLabelKey:  p.clusterName,
+			values.ClusterIdLabelKey:    p.clusterId,
 			values.LabelsLabelKey:       string(podLabels),
 			values.PodScheduledKey:      scheduled,
 			values.ResourceTypeLabelKey: "cost",
 		}
-		p.podResourceCostGV.With(labels).Set(cost)
+		ch <- prometheus.MustNewConstMetric(podResourceCostDesc,
+			prometheus.GaugeValue, cost, utils.ConvertPrometheusLabelValuesInOrder(containerNoneCareLabelKey, labels)...)
 	}
 }
 
-func (p *PodLevelMetricsCollector) collectPodResourceRequest(agentOptions *options.AgentOptions) {
+type podResourceRequestCollector struct {
+	clusterId   string
+	clusterName string
+
+	metricsClient *versioned.Clientset
+	provider      cloudprice.CloudProviderInterface
+
+	podLister  v1.PodLister
+	nodeLister v1.NodeLister
+}
+
+func (p *podResourceRequestCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- podResourceRequestDesc
+}
+
+func (p *podResourceRequestCollector) Collect(ch chan<- prometheus.Metric) {
 	pods, err := p.podLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("List all pods error:%v", err)
@@ -158,8 +146,8 @@ func (p *PodLevelMetricsCollector) collectPodResourceRequest(agentOptions *optio
 		labels := prometheus.Labels{
 			values.NamespaceLabelKey:   pod.Namespace,
 			values.PodNameLabelKey:     pod.Name,
-			values.ClusterNameLabelKey: agentOptions.ClusterName,
-			values.ClusterIdLabelKey:   agentOptions.ClusterId,
+			values.ClusterNameLabelKey: p.clusterName,
+			values.ClusterIdLabelKey:   p.clusterId,
 			values.LabelsLabelKey:      string(podLabels),
 		}
 		cpuRequest, memoryRequest := utils.ParsePodResourceRequest(pod.Spec.Containers)
@@ -167,18 +155,35 @@ func (p *PodLevelMetricsCollector) collectPodResourceRequest(agentOptions *optio
 		labels[values.ResourceTypeLabelKey] = string(corev1.ResourceCPU)
 		for containerName, cpu := range cpuRequest {
 			labels[values.ContainerNameLabelKey] = containerName
-			p.podResourceRequestGV.With(labels).Set(cpu)
+			ch <- prometheus.MustNewConstMetric(podResourceRequestDesc,
+				prometheus.GaugeValue, cpu, utils.ConvertPrometheusLabelValuesInOrder(containerCareLabelKey, labels)...)
 		}
 		labels[values.ResourceTypeLabelKey] = string(corev1.ResourceMemory)
 		for containerName, memory := range memoryRequest {
 			labels[values.ContainerNameLabelKey] = containerName
-			p.podResourceRequestGV.With(labels).Set(memory)
+			ch <- prometheus.MustNewConstMetric(podResourceRequestDesc,
+				prometheus.GaugeValue, memory, utils.ConvertPrometheusLabelValuesInOrder(containerCareLabelKey, labels)...)
 		}
 	}
 }
 
-func (p *PodLevelMetricsCollector) collectPodResourceUsage(ctx context.Context, agentOptions *options.AgentOptions) {
-	pods, err := p.metricsClient.MetricsV1beta1().PodMetricses(corev1.NamespaceAll).List(ctx, metav1.ListOptions{})
+type podResourceUsageCollector struct {
+	clusterId   string
+	clusterName string
+
+	metricsClient *versioned.Clientset
+	provider      cloudprice.CloudProviderInterface
+
+	podLister  v1.PodLister
+	nodeLister v1.NodeLister
+}
+
+func (p *podResourceUsageCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- podResourceUsageDesc
+}
+
+func (p *podResourceUsageCollector) Collect(ch chan<- prometheus.Metric) {
+	pods, err := p.metricsClient.MetricsV1beta1().PodMetricses(corev1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		klog.Errorf("List all pod metrics error:%v, kubernetes metrics server may not be installed", err)
 		return
@@ -198,8 +203,8 @@ func (p *PodLevelMetricsCollector) collectPodResourceUsage(ctx context.Context, 
 		labels := prometheus.Labels{
 			values.NamespaceLabelKey:   pod.Namespace,
 			values.PodNameLabelKey:     pod.Name,
-			values.ClusterNameLabelKey: agentOptions.ClusterName,
-			values.ClusterIdLabelKey:   agentOptions.ClusterId,
+			values.ClusterNameLabelKey: p.clusterName,
+			values.ClusterIdLabelKey:   p.clusterId,
 			values.LabelsLabelKey:      string(podLabels),
 		}
 		cpuUsage, memoryUsage := utils.ParsePodResourceUsage(pod.Containers)
@@ -207,12 +212,47 @@ func (p *PodLevelMetricsCollector) collectPodResourceUsage(ctx context.Context, 
 		labels[values.ResourceTypeLabelKey] = string(corev1.ResourceCPU)
 		for containerName, cpu := range cpuUsage {
 			labels[values.ContainerNameLabelKey] = containerName
-			p.podResourceUsageGV.With(labels).Set(cpu)
+			ch <- prometheus.MustNewConstMetric(podResourceUsageDesc,
+				prometheus.GaugeValue, cpu, utils.ConvertPrometheusLabelValuesInOrder(containerCareLabelKey, labels)...)
 		}
 		labels[values.ResourceTypeLabelKey] = string(corev1.ResourceMemory)
 		for containerName, memory := range memoryUsage {
 			labels[values.ContainerNameLabelKey] = containerName
-			p.podResourceUsageGV.With(labels).Set(memory)
+			ch <- prometheus.MustNewConstMetric(podResourceUsageDesc,
+				prometheus.GaugeValue, memory, utils.ConvertPrometheusLabelValuesInOrder(containerCareLabelKey, labels)...)
 		}
 	}
+}
+
+func RegisterPodLevelMetricsCollection(agentOptions *options.AgentOptions,
+	client *versioned.Clientset,
+	provider cloudprice.CloudProviderInterface,
+	podLister v1.PodLister,
+	nodeLister v1.NodeLister) {
+	podResourceCostCollector := &podResourceCostCollector{
+		clusterId:     agentOptions.ClusterId,
+		clusterName:   agentOptions.ClusterName,
+		metricsClient: client,
+		provider:      provider,
+		podLister:     podLister,
+		nodeLister:    nodeLister,
+	}
+	podResourceRequestCollector := &podResourceRequestCollector{
+		clusterId:     agentOptions.ClusterId,
+		clusterName:   agentOptions.ClusterName,
+		metricsClient: client,
+		provider:      provider,
+		podLister:     podLister,
+		nodeLister:    nodeLister,
+	}
+	podResuorceUsageCollector := &podResourceUsageCollector{
+		clusterId:     agentOptions.ClusterId,
+		clusterName:   agentOptions.ClusterName,
+		metricsClient: client,
+		provider:      provider,
+		podLister:     podLister,
+		nodeLister:    nodeLister,
+	}
+
+	prometheus.MustRegister(podResourceCostCollector, podResourceRequestCollector, podResuorceUsageCollector)
 }

--- a/pkg/server/implementation/cluster_metrics.go
+++ b/pkg/server/implementation/cluster_metrics.go
@@ -696,6 +696,10 @@ func queryAllClustersResourceSystemTaken(tenantId string) (map[string]map[string
 
 func ConvertToMultiClustersMetricsList(clusterMetrics map[string]*api.ClusterMetricsSummary, clustersProperty map[string]*api.ClusterBasicProperty) *api.ClusterMetricsSummaryList {
 	for cluterId := range clusterMetrics {
+		if _, ok := clustersProperty[cluterId]; !ok {
+			klog.Warningf("Cluster basic information is not found:%s, ignore it", cluterId)
+			continue
+		}
 		clusterMetrics[cluterId].ClusterBasicProperty = *clustersProperty[cluterId]
 	}
 

--- a/pkg/server/implementation/workload_cost.go
+++ b/pkg/server/implementation/workload_cost.go
@@ -67,9 +67,7 @@ func QueryWorkloadCostsWithTimeRange(tenantId, clusterId string,
 		go func() {
 			defer wg.Done()
 			podCosts, err = queryPodCostsWithTimeRange(tenantId, clusterId, start, end, stepSeconds)
-			if err != nil {
-				errs = append(errs, err)
-			}
+			errs = append(errs, err)
 		}()
 	}
 
@@ -79,14 +77,12 @@ func QueryWorkloadCostsWithTimeRange(tenantId, clusterId string,
 		go func() {
 			defer wg.Done()
 			workloadCosts, err = queryHighLevelWorkloadCostsWithTimeRange(tenantId, clusterId, start, end, stepSeconds, aggregateBy)
-			if err != nil {
-				errs = append(errs, err)
-			}
+			errs = append(errs, err)
 		}()
 	}
 
 	wg.Wait()
-	if len(errs) > 0 {
+	if errors.NewAggregate(errs) != nil {
 		return nil, errors.NewAggregate(errs)
 	}
 

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -113,4 +114,12 @@ func ConvertQualityToGiB(value resource.Quantity) float64 {
 
 func ConvertQualityToCore(value resource.Quantity) float64 {
 	return value.AsApproximateFloat64()
+}
+
+func ConvertPrometheusLabelValuesInOrder(keyOrder []string, labels prometheus.Labels) []string {
+	ret := []string{}
+	for _, key := range keyOrder {
+		ret = append(ret, labels[key])
+	}
+	return ret
 }


### PR DESCRIPTION
Part of https://github.com/kubefin/kubefin/issues/29

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* fix metrics redundancy when the pod not exists


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
`kubefin-core`: Fix continue reporting metrics when the resource(like pods) don't exist.
```
