### PR TITLE
Automated cherry pick of #46: bug: fix mimir CrashLoopBackOff

### DIFF
--- a/config_template/third_party/mimir.yaml
+++ b/config_template/third_party/mimir.yaml
@@ -22,6 +22,11 @@ spec:
         image: grafana/mimir:2.6.0
         imagePullPolicy: IfNotPresent
         name: mimir
+        env:
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
         ports:
           - containerPort: 9009
             name: http

--- a/config_template/third_party/mimir_config.yaml
+++ b/config_template/third_party/mimir_config.yaml
@@ -55,3 +55,7 @@ data:
     # 2.https://grafana.com/docs/mimir/latest/references/configuration-parameters/
     frontend:
       max_outstanding_per_tenant: 4096
+
+    memberlist:
+      bind_addr:
+      - ${MY_POD_IP}


### PR DESCRIPTION
Cherry pick of #46 on release-0.1.

#46: bug: fix mimir CrashLoopBackOff

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```