### PR TITLE
Support metrics of gpu resource for default provider

### DIFF
--- a/cmd/kubefin-agent/app/options/options.go
+++ b/cmd/kubefin-agent/app/options/options.go
@@ -37,11 +37,14 @@ type AgentOptions struct {
 	ClusterName   string
 	ClusterId     string
 
-	NodeCPUCoreDeviation   string
-	NodeRAMGBDeviation     string
-	CPUMemoryCostRatio     string
-	CustomCPUCoreHourPrice string
-	CustomRAMGBHourPrice   string
+	NodeCPUCoreDeviation     string
+	NodeRAMGBDeviation       string
+	CPUMemoryCostRatio       string
+	CustomCPUCoreHourPrice   string
+	CustomRAMGBHourPrice     string
+	CustomGPUCardHourPrice   string
+	CustomGPUDeviceLabelKey  string
+	CustomGPUDevicePriceList string
 }
 
 // NewAgentOptions builds an empty options.
@@ -55,16 +58,19 @@ func NewAgentOptions() *AgentOptions {
 			RenewDeadline:     metav1.Duration{Duration: values.DefaultRenewDeadline},
 			RetryPeriod:       metav1.Duration{Duration: values.DefaultRetryPeriod},
 		},
-		ScrapMetricsInterval:   values.DefaultMetricsQueryPeriod,
-		LeaderElectionID:       os.Getenv(values.LeaderElectionIDEnv),
-		CloudProvider:          os.Getenv(values.CloudProviderEnv),
-		ClusterName:            os.Getenv(values.ClusterNameEnv),
-		ClusterId:              os.Getenv(values.ClusterIdEnv),
-		CPUMemoryCostRatio:     os.Getenv(values.CPUMemoryCostRatioEnv),
-		CustomCPUCoreHourPrice: os.Getenv(values.CustomCPUCoreHourPriceEnv),
-		CustomRAMGBHourPrice:   os.Getenv(values.CustomRAMGBHourPriceEnv),
-		NodeCPUCoreDeviation:   os.Getenv(values.NodeCPUDeviationEnv),
-		NodeRAMGBDeviation:     os.Getenv(values.NodeRAMDeviationEnv),
+		ScrapMetricsInterval:     values.DefaultMetricsQueryPeriod,
+		LeaderElectionID:         os.Getenv(values.LeaderElectionIDEnv),
+		CloudProvider:            os.Getenv(values.CloudProviderEnv),
+		ClusterName:              os.Getenv(values.ClusterNameEnv),
+		ClusterId:                os.Getenv(values.ClusterIdEnv),
+		CPUMemoryCostRatio:       os.Getenv(values.CPUMemoryCostRatioEnv),
+		CustomCPUCoreHourPrice:   os.Getenv(values.CustomCPUCoreHourPriceEnv),
+		CustomRAMGBHourPrice:     os.Getenv(values.CustomRAMGBHourPriceEnv),
+		CustomGPUCardHourPrice:   os.Getenv(values.CustomGPUCardHourPriceEnv),
+		CustomGPUDeviceLabelKey:  os.Getenv(values.CustomGPUDeviceLabelKeyEnv),
+		CustomGPUDevicePriceList: os.Getenv(values.CustomGPUDevicePriceListEnv),
+		NodeCPUCoreDeviation:     os.Getenv(values.NodeCPUDeviationEnv),
+		NodeRAMGBDeviation:       os.Getenv(values.NodeRAMDeviationEnv),
 	}
 }
 

--- a/config_template/core/deployments/kubefin-agent.yaml
+++ b/config_template/core/deployments/kubefin-agent.yaml
@@ -66,6 +66,15 @@ spec:
           # This only used when we can't recognize the cloud provider or default
           - name: CUSTOM_RAM_GB_HOUR_PRICE
             value: ""
+          # This only used when we can't recognize the cloud provider or default
+          - name: CUSTOM_GPU_CARD_HOUR_PRICE
+            value: ""
+          # This only used when we can't recognize the cloud provider or default
+          - name: CUSTOM_GPU_DEVICE_LABEL_KEY
+            value: ""
+          # This only used when we can't recognize the cloud provider or default
+          - name: CUSTOM_GPU_DEVICE_PRICE_LIST
+            value: ""
           # the eatch node CPU deviation core between the actual core and the one obtained from node.status.capacity, this only used when we can't recognize the cloud provider
           - name: NODE_CPU_DEVIATION
             value: "0.0"

--- a/pkg/api/agent_types.go
+++ b/pkg/api/agent_types.go
@@ -30,6 +30,8 @@ type InstancePriceInfo struct {
 	CPUCoreHourlyPrice   float64
 	RamGiB               float64
 	RAMGiBHourlyPrice    float64
+	GPUCards             float64
+	GPUCardHourlyPrice   float64
 	InstanceType         string
 	BillingMode          string
 

--- a/pkg/cloudprice/defaultcloud/provider.go
+++ b/pkg/cloudprice/defaultcloud/provider.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,12 +35,16 @@ import (
 const (
 	defaultCpuCoreHourlyPrice = 0.08
 	defaultRamGBHourlyPrice   = 0.02
+	defaultGpuCardHourlyPrice = 12.80
 )
 
 type DefaultCloudProvider struct {
 	client               kubernetes.Interface
 	CpuCoreHourlyPrice   float64
 	RamGBHourlyPrice     float64
+	GpuCardHourlyPrice   float64
+	GPUDeviceLabelKey    string
+	GPUDevicePriceList   string
 	NodeCPUCoreDeviation string
 	NodeRAMGBDeviation   string
 }
@@ -47,14 +52,12 @@ type DefaultCloudProvider struct {
 func NewDefaultCloudProvider(client kubernetes.Interface, agentOptions *options.AgentOptions) (*DefaultCloudProvider, error) {
 	var err error
 
-	cpuCoreHourlyPrice, ramGBHourlyPrice := defaultCpuCoreHourlyPrice, defaultRamGBHourlyPrice
+	cpuCoreHourlyPrice, ramGBHourlyPrice, gpuCardHourlyPrice := defaultCpuCoreHourlyPrice, defaultRamGBHourlyPrice, defaultGpuCardHourlyPrice
 	if agentOptions.CustomCPUCoreHourPrice != "" {
 		cpuCoreHourlyPrice, err = strconv.ParseFloat(agentOptions.CustomCPUCoreHourPrice, 64)
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		cpuCoreHourlyPrice = defaultCpuCoreHourlyPrice
 	}
 
 	if agentOptions.CustomRAMGBHourPrice != "" {
@@ -62,16 +65,24 @@ func NewDefaultCloudProvider(client kubernetes.Interface, agentOptions *options.
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		ramGBHourlyPrice = defaultRamGBHourlyPrice
+	}
+
+	if agentOptions.CustomGPUCardHourPrice != "" {
+		gpuCardHourlyPrice, err = strconv.ParseFloat(agentOptions.CustomGPUCardHourPrice, 64)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	defaultCloud := DefaultCloudProvider{
 		client:               client,
 		CpuCoreHourlyPrice:   cpuCoreHourlyPrice,
 		RamGBHourlyPrice:     ramGBHourlyPrice,
+		GpuCardHourlyPrice:   gpuCardHourlyPrice,
 		NodeCPUCoreDeviation: agentOptions.NodeCPUCoreDeviation,
 		NodeRAMGBDeviation:   agentOptions.NodeRAMGBDeviation,
+		GPUDeviceLabelKey:    agentOptions.CustomGPUDeviceLabelKey,
+		GPUDevicePriceList:   agentOptions.CustomGPUDevicePriceList,
 	}
 
 	return &defaultCloud, nil
@@ -98,8 +109,11 @@ func (c *DefaultCloudProvider) ParseClusterInfo(agentOptions *options.AgentOptio
 func (c *DefaultCloudProvider) GetNodeHourlyPrice(node *v1.Node) (*api.InstancePriceInfo, error) {
 	cpuCoresQuantity := node.Status.Capacity[v1.ResourceCPU]
 	ramBytesQuantity := node.Status.Capacity[v1.ResourceMemory]
+	gpuCardsQuantity := node.Status.Capacity[values.ResourceGPU]
 	cpuCores := cpuCoresQuantity.AsApproximateFloat64()
 	ramBytes := ramBytesQuantity.AsApproximateFloat64()
+	gpuCards := gpuCardsQuantity.AsApproximateFloat64()
+	gpuCardHourlyPrice := c.GpuCardHourlyPrice
 
 	// we can't get real cpu/ram from node.status, take env and add it
 	var err error
@@ -121,16 +135,57 @@ func (c *DefaultCloudProvider) GetNodeHourlyPrice(node *v1.Node) (*api.InstanceP
 		}
 	}
 
+	if c.GPUDeviceLabelKey != "" && c.GPUDevicePriceList != "" {
+		priceList, err := parseGPUDevicePriceList(c.GPUDevicePriceList)
+		if err != nil {
+			klog.Errorf("Parse %s error:%v", c.GPUDevicePriceList, err)
+			return nil, err
+		}
+
+		deviceName, labelExists := node.Labels[c.GPUDeviceLabelKey]
+		if labelExists {
+			if price, exists := priceList[deviceName]; exists {
+				gpuCardHourlyPrice = price
+			} else {
+				klog.V(4).Infof("Unknown device price, use generic GPU card hourly price")
+			}
+		} else {
+			klog.V(4).Info("Unknown device, use generic GPU card hourly price")
+		}
+	}
+
 	return &api.InstancePriceInfo{
-		NodeTotalHourlyPrice: c.CpuCoreHourlyPrice*cpuCores + c.RamGBHourlyPrice*(ramBytes/values.GBInBytes),
+		NodeTotalHourlyPrice: c.CpuCoreHourlyPrice*cpuCores + c.RamGBHourlyPrice*(ramBytes/values.GBInBytes) + c.GpuCardHourlyPrice*gpuCards,
 		CPUCore:              cpuCores + CPUCoreDeviation,
 		CPUCoreHourlyPrice:   c.CpuCoreHourlyPrice,
 		RamGiB:               (ramBytes / values.GBInBytes) + RAMGBDeviation,
 		RAMGiBHourlyPrice:    c.RamGBHourlyPrice,
+		GPUCards:             gpuCards,
+		GPUCardHourlyPrice:   gpuCardHourlyPrice,
 		InstanceType:         "default_instance_type",
 		BillingMode:          values.BillingModeOnDemand,
 		BillingPeriod:        0,
 		Region:               "default_region",
 		CloudProvider:        api.CloudProviderOnPremise,
 	}, nil
+}
+
+// Example T1:12;A100:15
+func parseGPUDevicePriceList(priceList string) (map[string]float64, error) {
+	deviceItems := strings.Split(priceList, ";")
+	ret := make(map[string]float64, len(deviceItems))
+	for _, deviceItem := range deviceItems {
+		splitDeviceItem := strings.Split(deviceItem, ":")
+		if len(splitDeviceItem) != 2 {
+			return nil, fmt.Errorf("failed to parse GPU device price list")
+		}
+		deviceName, price := splitDeviceItem[0], splitDeviceItem[1]
+		priceAsFloat, err := strconv.ParseFloat(price, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse price of %v", deviceName)
+		}
+		ret[deviceName] = priceAsFloat
+	}
+
+	return ret, nil
 }

--- a/pkg/cloudprice/defaultcloud/provider_test.go
+++ b/pkg/cloudprice/defaultcloud/provider_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2023 The KubeFin Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultcloud
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func Test_parseGPUDevicePriceList(t *testing.T) {
+	tests := []struct {
+		name      string
+		priceList string
+		wantMap   map[string]float64
+		wantErr   error
+	}{
+		{
+			name:      "empty",
+			priceList: "",
+			wantMap:   nil,
+			wantErr:   fmt.Errorf("failed to parse GPU device price list"),
+		},
+		{
+			name:      "correct input",
+			priceList: "T1:12;A100:15",
+			wantMap: map[string]float64{
+				"A100": 15,
+				"T1":   12,
+			},
+			wantErr: nil,
+		},
+		{
+			name:      "wrong input",
+			priceList: "T1:12:12;A100:15",
+			wantMap:   nil,
+			wantErr:   fmt.Errorf("failed to parse GPU device price list"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ret, err := parseGPUDevicePriceList(tt.priceList)
+			if !reflect.DeepEqual(ret, tt.wantMap) || !reflect.DeepEqual(err, tt.wantErr) {
+				t.Errorf("parseGPUDevicePriceList() want (%v, %v), but got (%v, %v)", tt.wantMap, tt.wantErr,
+					ret, err)
+			}
+		})
+	}
+}

--- a/pkg/values/default.go
+++ b/pkg/values/default.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package values
 
-import "time"
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+)
 
 const (
 	KubeFinNamespace = "kubefin"
@@ -58,10 +62,34 @@ const (
 	CustomCPUCoreHourPriceEnv = "CUSTOM_CPU_CORE_HOUR_PRICE"
 	CustomRAMGBHourPriceEnv   = "CUSTOM_RAM_GB_HOUR_PRICE"
 
+	// CustomGPUCardHourPriceEnv indicates price per hour for an nvidia GPU card,
+	// and it does not distinguish the specific device of the GPU card.
+	// Because Kubernetes treats extended resources such as GPU as scalar resources by default.
+	// Whether it is T4 or A100, it's regarded as one "nvidia.com/gpu" resource.
+	CustomGPUCardHourPriceEnv = "CUSTOM_GPU_CARD_HOUR_PRICE"
+	// CustomGPUDeviceLabelKeyEnv indicates the key of label which indicates the type of GPUs.
+	// If different nodes in the cluster have different types of GPUs,
+	// Kubernetes recommends using Node Labels and Node Selectors to schedule pods to appropriate nodes.
+	// See https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/#clusters-containing-different-types-of-gpus.
+	// Kubefin supports using user-specified labels to identify specific GPU devices and calculate their prices.
+	// You can also use GPU feature discovery to implement automatic node labelling.
+	// See details in https://github.com/NVIDIA/gpu-feature-discovery/blob/main/README.md.
+	CustomGPUDeviceLabelKeyEnv = "CUSTOM_GPU_DEVICE_LABEL_KEY"
+	// CustomGPUDevicePriceListEnv indicates price list of different types of GPUs.
+	// It will use ";" to separate different device items and use ":" to separate device name and price per hour.
+	// CustomGPUDevicePriceListEnv needs to be used together with CustomGPUDeviceLabelKeyEnv.
+	// Example:
+	// A100:12;T4:15
+	CustomGPUDevicePriceListEnv = "CUSTOM_GPU_DEVICE_PRICE_LIST"
+
 	MultiTenantHeader       = "X-Scope-OrgID"
 	ClusterIdQueryParameter = "cluster_id"
 
 	DefaultStepSeconds = 3600
 	// DefaultDetailStepSeconds is used to show the fine-grained line chart of cpu/memory data
 	DefaultDetailStepSeconds = 600
+)
+
+const (
+	ResourceGPU = v1.ResourceName("nvidia.com/gpu")
 )

--- a/pkg/values/metrics.go
+++ b/pkg/values/metrics.go
@@ -24,6 +24,7 @@ var (
 	NodeCPUCoreHourlyCostMetricsName  = "kubefin_node_cpu_core_hourly_cost"
 	NodeCPUHourlyCostMetricsName      = "kubefin_node_cpu_hourly_cost"
 	NodeRAMGBHourlyCostMetricsName    = "kubefin_node_ram_gb_hourly_cost"
+	NodeGPUCardHourlyCostMetricsName  = "kubefin_node_gpu_card_hourly_cost"
 	NodeResourceHourlyCostMetricsName = "kubefin_node_resource_hourly_cost"
 	NodeRAMHourlyCostMetricsName      = "kubefin_node_ram_hourly_cost"
 	NodeTotalHourlyCostMetricsName    = "kubefin_node_total_hourly_cost"


### PR DESCRIPTION
For details, please see comments in pkg/values/default.go.

Test Result:
```
kubefin_node_gpu_card_hourly_cost{billing_mode="ondemand",billing_period="0",cloud_provider="onpremise",cluster_id="f2e3ebb0-48a7-4a07-9fac-1b8037556e3a",cluster_name="cluster-1",instance_type="default_instance_type",node="cluster-1-control-plane",region="default_region"} 12.8
kubefin_node_gpu_card_hourly_cost{billing_mode="ondemand",billing_period="0",cloud_provider="onpremise",cluster_id="f2e3ebb0-48a7-4a07-9fac-1b8037556e3a",cluster_name="cluster-1",instance_type="default_instance_type",node="kwok-node-0",region="default_region"} 12
kubefin_node_resource_available{billing_mode="ondemand",cluster_id="f2e3ebb0-48a7-4a07-9fac-1b8037556e3a",cluster_name="cluster-1",node="cluster-1-control-plane",resource="cpu"} 1.86
kubefin_node_resource_available{billing_mode="ondemand",cluster_id="f2e3ebb0-48a7-4a07-9fac-1b8037556e3a",cluster_name="cluster-1",node="cluster-1-control-plane",resource="memory"} 4.345165252685547
kubefin_node_resource_available{billing_mode="ondemand",cluster_id="f2e3ebb0-48a7-4a07-9fac-1b8037556e3a",cluster_name="cluster-1",node="cluster-1-control-plane",resource="[nvidia.com/gpu](http://nvidia.com/gpu)"} 0
kubefin_node_resource_available{billing_mode="ondemand",cluster_id="f2e3ebb0-48a7-4a07-9fac-1b8037556e3a",cluster_name="cluster-1",node="kwok-node-0",resource="cpu"} 31.900000000000002
kubefin_node_resource_available{billing_mode="ondemand",cluster_id="f2e3ebb0-48a7-4a07-9fac-1b8037556e3a",cluster_name="cluster-1",node="kwok-node-0",resource="memory"} 255.951171875
kubefin_node_resource_available{billing_mode="ondemand",cluster_id="f2e3ebb0-48a7-4a07-9fac-1b8037556e3a",cluster_name="cluster-1",node="kwok-node-0",resource="[nvidia.com/gpu](http://nvidia.com/gpu)"} 10
```

**Release Note**
```release-note
kubefin-agent: support metrics of gpu resource for default provider
```
