### PR TITLE
debug: add mimir datasource in grafana by default

### DIFF
--- a/config_template/third_party/grafana.yaml
+++ b/config_template/third_party/grafana.yaml
@@ -49,6 +49,13 @@ spec:
             requests:
               cpu: 250m
               memory: 750Mi
+          volumeMounts:
+          - mountPath: /etc/grafana/provisioning/datasources
+            name: grafana-datasources
+      volumes:
+        - name: grafana-datasources
+          configMap:
+            name: grafana-datasources
 ---
 apiVersion: v1
 kind: Service

--- a/config_template/third_party/grafana_config.yaml
+++ b/config_template/third_party/grafana_config.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: kubefin
+data:
+  datasources.yaml: |-
+    {
+        "apiVersion": 1,
+        "datasources": [
+            {
+                "access": "proxy",
+                "editable": false,
+                "name": "kubefin",
+                "orgId": 1,
+                "type": "prometheus",
+                "url": "http://mimir.kubefin.svc.cluster.local:9009/prometheus",
+                "version": 1
+            }
+        ]
+    }

--- a/config_template/third_party/mimir.yaml
+++ b/config_template/third_party/mimir.yaml
@@ -36,10 +36,10 @@ spec:
             memory: 1Gi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-            - mountPath: /etc/mimir/config.yaml
-              name: mimir-config
-              subPath: config.yaml
-              readOnly: true
+          - mountPath: /etc/mimir/config.yaml
+            name: mimir-config
+            subPath: config.yaml
+            readOnly: true
         readinessProbe:
           httpGet:
             path: /ready


### PR DESCRIPTION
Fixes #69 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* debug: add mimir datasource in grafana by default

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
