### PR TITLE
fix: correct the single cluster CPU dashboard that is missing the system reserved section

### DIFF
--- a/dashboard/web/src/pages/dashboard/components/model/cpu.jsx
+++ b/dashboard/web/src/pages/dashboard/components/model/cpu.jsx
@@ -14,7 +14,6 @@ export class CPU {
     this.CPUUsage = CPUUsage;
     this.totalCPUArray = totalCPUArray;
     this.systemReservedCPUArray = systemReservedCPUArray;
-    this.systemReservedCPUArray = systemReservedCPUArray;
     this.requestedCPUArray = requestedCPUArray;
     this.availableCPUArray = availableCPUArray;
   }

--- a/dashboard/web/src/pages/dashboard/components/single-cluster/cluster-cpu-utilization.jsx
+++ b/dashboard/web/src/pages/dashboard/components/single-cluster/cluster-cpu-utilization.jsx
@@ -34,7 +34,7 @@ export default function ClusterCPUUtilization(props) {
 
   const requestedCPUArray = cluster.CPU.requestedCPUArray;
   const availableCPUArray = cluster.CPU.availableCPUArray;
-  const systemReservedArray = cluster.CPU.systemReservedArray;
+  const systemReservedArray = cluster.CPU.systemReservedCPUArray;
   const totalCPUArray = cluster.CPU.totalCPUArray;
 
   var cpuRequestedData = ParseArrayIntoTimeSeriesData(requestedCPUArray);


### PR DESCRIPTION
Fixes #none

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* fix: correct the single cluster CPU dashboard that is missing the system reserved section


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
`kubefin-dashboard`: correct the single cluster CPU dashboard that is missing the system reserved section.
```
