### PR TITLE
fix: avoid querying API resources too frequently

### DIFF
--- a/cmd/kubefin-agent/app/agent.go
+++ b/cmd/kubefin-agent/app/agent.go
@@ -129,7 +129,10 @@ func Run(ctx context.Context, opts *options.AgentOptions) error {
 		k8sFactory := informers.NewSharedInformerFactory(client, 0)
 		kubefinFactory := kubefininformer.NewSharedInformerFactory(kubefinClient, 0)
 		coreResourceInformerLister := getAllCoreResourceLister(k8sFactory, kubefinFactory)
-		metrics.RegisterAgentMetricsCollector(ctx, opts, coreResourceInformerLister, provider, metricsClientList)
+		if err := metrics.RegisterAgentMetricsCollector(ctx, opts, coreResourceInformerLister,
+			provider, metricsClientList); err != nil {
+			klog.Fatalf("Register agent metrics collector error:%v", err)
+		}
 
 		stopCh := ctx.Done()
 		k8sFactory.Start(stopCh)

--- a/pkg/agent/metrics/agent_metrics.go
+++ b/pkg/agent/metrics/agent_metrics.go
@@ -30,14 +30,15 @@ func RegisterAgentMetricsCollector(ctx context.Context,
 	options *options.AgentOptions,
 	coreResourceInformerLister *options.CoreResourceInformerLister,
 	provider cloudprice.CloudProviderInterface,
-	metricsClientList *types.MetricsClientList) {
+	metricsClientList *types.MetricsClientList) error {
 	usageMetricsCache := metricscache.NewClusterResourceUsageMetricsCache(ctx, options, metricsClientList)
 	core.RegisterClusterLevelMetricsCollection(options, provider, coreResourceInformerLister)
 	core.RegisterPodLevelMetricsCollection(options, provider, coreResourceInformerLister, usageMetricsCache)
 	core.RegisterNodeLevelMetricsCollection(options, provider, coreResourceInformerLister, usageMetricsCache)
-	core.RegisterWorkloadLevelMetricsCollection(options, provider, coreResourceInformerLister, usageMetricsCache, metricsClientList)
+	if err := core.RegisterWorkloadLevelMetricsCollection(ctx, options, provider,
+		coreResourceInformerLister, usageMetricsCache, metricsClientList); err != nil {
+		return err
+	}
 
-	go func() {
-		usageMetricsCache.Start()
-	}()
+	return nil
 }

--- a/pkg/agent/metrics/cache/usage_cache.go
+++ b/pkg/agent/metrics/cache/usage_cache.go
@@ -58,7 +58,7 @@ type ClusterResourceUsageMetricsCache struct {
 func NewClusterResourceUsageMetricsCache(ctx context.Context,
 	agentOptions *options.AgentOptions,
 	metricsClientList *types.MetricsClientList) *ClusterResourceUsageMetricsCache {
-	return &ClusterResourceUsageMetricsCache{
+	usageMetricsCache := &ClusterResourceUsageMetricsCache{
 		ctx:           ctx,
 		metricsClient: metricsClientList.MetricsClient,
 		options:       agentOptions,
@@ -67,6 +67,9 @@ func NewClusterResourceUsageMetricsCache(ctx context.Context,
 		nodeMutex:     sync.RWMutex{},
 		nodesUsage:    []ResourceUsageMetric{},
 	}
+	go usageMetricsCache.Start()
+
+	return usageMetricsCache
 }
 
 func (c *ClusterResourceUsageMetricsCache) Start() {


### PR DESCRIPTION
Fixes #107 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* fix: avoid querying API resources too frequently

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
`kubefin-core`: avoid querying API resources too frequently, causing trigger flow control, thus unable to collect data.
```
